### PR TITLE
Feat/support pep 695 syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "generic-preserver"
 description = "Extracting Generic Type References in Python"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Matthew Coulter <mattcoul7@gmail.com>"]
 readme = "README.md"
 packages = [{ include = "generic_preserver", from = "src" }]

--- a/src/generic_preserver/metaclass.py
+++ b/src/generic_preserver/metaclass.py
@@ -1,5 +1,5 @@
-from typing import Iterable, get_args
-
+from typing import get_args
+from typing import Any
 from .utils import (
     copy_class_metadata,
     is_generic_type,
@@ -85,11 +85,11 @@ class GenericMeta(type):
                 base for base in cls.__orig_bases__
                 if is_generic_type(base)
             )
-        except StopIteration:
+        except StopIteration as e:
             # no generics in this class
             raise RuntimeError(
                 f"Unable to find generic argument in class `{repr(cls)}`"
-            )
+            ) from e
 
         # lookup required arguments
         type_vars = get_args(generic_base)
@@ -100,38 +100,68 @@ class GenericMeta(type):
 
         # looking up existing generic map to ensure we still capture
         # generics from super class
-        existing_generic_map = cls.__generic_map__ if hasattr(cls, "__generic_map__") else {}
+        existing_generic_map = getattr(cls, "__generic_map__", {})
 
-        # create the class wrapper, which stores the generic instances mapped to type vars
+        def canonical_key(tp: Any) -> Any:
+            """
+            Produce a stable key for a type parameter.
+
+            - For TypeVar / PEP 695 type parameters: use their name
+              (`.__name__` or `.name`).
+            - For non-type-parameters: just use the object itself.
+            """
+            name = getattr(tp, "__name__", None)
+            return name if name is not None else tp
+
+        def resolve_type_reference(ref: Any) -> Any:
+            """
+            If the type argument is itself a type parameter that already has
+            a concrete binding in `existing_generic_map`, return that binding.
+
+            This is the critical bit that fixes your PEP 695 issue where
+            `B` was ending up bound to *another* type parameter instead of the
+            final concrete type.
+            """
+            key = canonical_key(ref)
+            return existing_generic_map.get(key, ref)
+
+        # Build the new mapping for this specialisation
+        new_entries = {
+            canonical_key(param): resolve_type_reference(type_ref)
+            for param, type_ref in zip(type_vars, type_references)
+        }
+
+        # Create the specialised class that remembers all resolved bindings
         class PreservedGeneric(cls):
             """
-            A Special Kind of Generic which preserves the type references passed
-            into the generic
+            A specialised generic that preserves the type arguments in
+            `__generic_map__`.
             """
-            __generic_map__ = existing_generic_map | {
-                var: type_ref
-                for var, type_ref in zip(type_vars, type_references)
-            }
+            __generic_map__ = {**existing_generic_map, **new_entries}
 
-            def __getitem__(self, item):
+            def __getitem__(self, item: Any):
                 """
-                Tries to retrieve the type from __generic_map__ if available,
-                whilst preserving any other implementations of __getitem__
+                Resolve generic parameters from `__generic_map__`, with support
+                for multi-lookup: `self[A, B]`.
                 """
-                # support multi retrieval ExampleA, ExampleB = self[A, B]
+                # Support e.g. ExampleA, ExampleB = self[A, B]
                 if isinstance(item, tuple):
                     return tuple(self[child_item] for child_item in item)
 
-                if item in self.__generic_map__:
-                    return self.__generic_map__[item]
-                
+                key = canonical_key(item)
+
+                if key in self.__generic_map__:
+                    return self.__generic_map__[key]
+
+                # Fall back to other __getitem__ implementations, if any
                 try:
                     return super().__getitem__(item)
-                except AttributeError:
+                except AttributeError as e:
                     raise KeyError(
                         f"No generic type found for generic arg {repr(item)}"
-                    )
+                    ) from e
 
+        # Preserve basic metadata (name, qualname, etc.)
         copy_class_metadata(PreservedGeneric, cls)
 
         return PreservedGeneric

--- a/tests/test_abstraction.py
+++ b/tests/test_abstraction.py
@@ -9,7 +9,7 @@ from abc import ABC
 from generic_preserver.wrapper import generic_preserver
 
 
-def test_template():
+def test():
     T = TypeVar("T")
 
     class ExampleT: pass

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,3 +1,5 @@
+"""Testing compatibility with python Generics >=3.5,<3.12."""
+
 import pytest
 
 from typing import (
@@ -8,7 +10,7 @@ from typing import (
 from generic_preserver.wrapper import generic_preserver
 
 
-def test_template():
+def test():
     A = TypeVar("A")
     B = TypeVar("B")
     C = TypeVar("C")
@@ -44,7 +46,7 @@ def test_template():
 
     # check invalid type through a KeyError
     D = TypeVar("D")
-    with pytest.raises(KeyError) as exc_info:
+    with pytest.raises(KeyError):
         # Code that should raise the exception
         instance[D]
 

--- a/tests/test_inheritance_pep_695.py
+++ b/tests/test_inheritance_pep_695.py
@@ -1,9 +1,11 @@
+"""Testing compatibility with python Generics >=3.12."""
+
 import pytest
 
 from generic_preserver.wrapper import generic_preserver
 
 
-def test_template():
+def test():
     class ExampleA: ...
     class ExampleB: ...
     class ExampleC: ...

--- a/tests/test_pep_695.py
+++ b/tests/test_pep_695.py
@@ -1,0 +1,63 @@
+import pytest
+
+from generic_preserver.wrapper import generic_preserver
+
+
+def test_template():
+    class ExampleA: ...
+    class ExampleB: ...
+    class ExampleC: ...
+
+    @generic_preserver
+    class Parent[A, B]:
+        @property
+        def a(self):  # noqa: N802
+            return self[A]
+
+        @property
+        def b(self):  # noqa: N802
+            return self[B]
+
+    class Child[B, C](Parent[ExampleA, B]):
+        @property
+        def c(self):  # noqa: N802
+            return self[C]
+
+    class GrandChild[C](Child[ExampleB, C]):
+        pass
+
+    instance = GrandChild[ExampleC]()
+
+    # check single type extraction (via properties)
+    assert instance.a is ExampleA
+    assert instance.b is ExampleB
+    assert instance.c is ExampleC
+
+    # With PEP-695, we no longer have global type vars. This first
+    # caused issues as under-the-hood, generic preservver would see
+    # 2 different B TypeVars, where previously they would be the same
+    # global instance.
+    #
+    # To support this, generic preserver now computes a canonical key
+    # using TypeVar(...).__name__, which in turn allows us to access the
+    # instances via a string.
+    #
+    # I don't recommend this, as the property approach keeps things clean
+    # but the test ensures that it is in fact working.
+    assert instance["A", "B", "C"] == (ExampleA, ExampleB, ExampleC)
+
+    # check invalid type through a KeyError
+    class D:  # sentinel type key that should not exist
+        pass
+
+    with pytest.raises(KeyError):
+        instance[D]
+
+    # check generic of generic
+    class ExampleD[D]: ...
+
+    instance_2 = Parent[ExampleA, ExampleD[ExampleB]]()
+
+    assert instance_2.a is ExampleA
+    assert instance_2.b is ExampleD[ExampleB]
+    assert instance_2["A", "B"] == (ExampleA, ExampleD[ExampleB])


### PR DESCRIPTION
    # With PEP-695, we no longer have global type vars. This first
    # caused issues as under-the-hood, generic preservver would see
    # 2 different B TypeVars, where previously they would be the same
    # global instance.
    #
    # To support this, generic preserver now computes a canonical key
    # using TypeVar(...).__name__, which in turn allows us to access the
    # instances via a string.
    #
    # I don't recommend this, as the property approach keeps things clean
    # but the test ensures that it is in fact working.