### PR TITLE
Feat/pydantic type error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,4 @@ python = ">=3.9"
 pytest = {version = "^8.3.3"}
 debugpy = {version = "^1.8.6"}
 pydantic = "^2.12.5"
+ruff = "^0.14.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,4 @@ python = ">=3.9"
 [tool.poetry.group.dev.dependencies]
 pytest = {version = "^8.3.3"}
 debugpy = {version = "^1.8.6"}
+pydantic = "^2.12.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "generic-preserver"
 description = "Extracting Generic Type References in Python"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Matthew Coulter <mattcoul7@gmail.com>"]
 readme = "README.md"
 packages = [{ include = "generic_preserver", from = "src" }]

--- a/src/generic_preserver/conflict_management.py
+++ b/src/generic_preserver/conflict_management.py
@@ -5,10 +5,7 @@ from typing import (
 )
 
 
-def get_metaclasses(
-    cls: Type,
-    seen=None
-) -> List[Type]:
+def get_metaclasses(cls: Type, seen=None) -> List[Type]:
     """
     Retrieves a list of metaclasses used by cls and its base classes,
     preserving order and avoiding duplicates.
@@ -30,9 +27,7 @@ def get_metaclasses(
             seen.add(base_meta)
             metaclasses.append(base_meta)
             # Recursively collect metaclasses from base classes
-            metaclasses.extend(
-                m for m in get_metaclasses(base, seen) if m not in seen
-            )
+            metaclasses.extend(m for m in get_metaclasses(base, seen) if m not in seen)
 
     return metaclasses
 
@@ -55,12 +50,7 @@ def build_combined_metaclass(
     # Remove duplicates while preserving order and exclude 'type'
     seen = set()
     metaclasses = [
-        m for m in metaclasses
-        if (
-            m not in seen
-            and not seen.add(m)
-            and m is not type
-        )
+        m for m in metaclasses if (m not in seen and not seen.add(m) and m is not type)
     ]
 
     # If there's only one metaclass, return it directly
@@ -70,11 +60,7 @@ def build_combined_metaclass(
     # Attempt to create a combined metaclass
     try:
         # The name 'CombinedMeta' is arbitrary and can be adjusted
-        return type(
-            'CombinedMeta',
-            tuple(metaclasses),
-            {}
-        )
+        return type("CombinedMeta", tuple(metaclasses), {})
 
     except TypeError as e:
         # Metaclass conflict occurred

--- a/src/generic_preserver/metaclass.py
+++ b/src/generic_preserver/metaclass.py
@@ -5,6 +5,11 @@ from .utils import (
     is_generic_type,
 )
 
+try:
+    from pydantic import BaseModel as PydanticBaseModel
+except ImportError:
+    PydanticBaseModel = None
+
 
 class GenericMeta(type):
     """
@@ -68,10 +73,64 @@ class GenericMeta(type):
         return super().__call__(*args, **kwargs)
 
     def __getitem__(cls, item):
+        if PydanticBaseModel is not None and isinstance(cls, type) and issubclass(cls, _PydanticBaseModel):
+            # Let Pydantic handle the generic specialisation first
+            submodel = cls.__class_getitem__(item)  # type: ignore[attr-defined]
+
+            # Work out the "origin" generic model and its type parameters
+            meta_sub = getattr(submodel, "__pydantic_generic_metadata__", {}) or {}
+            origin = meta_sub.get("origin") or cls
+
+            origin_meta = getattr(origin, "__pydantic_generic_metadata__", {}) or {}
+            params = origin_meta.get("parameters") or getattr(origin, "__parameters__", ())
+
+            # Concrete type arguments – prefer what's in the metadata
+            args = meta_sub.get("args")
+            if not args:
+                args = item if isinstance(item, tuple) else (item,)
+
+            existing_generic_map = getattr(cls, "__generic_map__", {})
+
+            def canonical_key(tp: Any) -> Any:
+                name = getattr(tp, "__name__", None)
+                return name if name is not None else tp
+
+            def resolve_type_reference(ref: Any) -> Any:
+                # Allow chaining: if the argument is itself a type variable,
+                # we might already have a concrete mapping for it higher up.
+                key = canonical_key(ref)
+                return existing_generic_map.get(key, ref)
+
+            new_entries = {
+                canonical_key(param): resolve_type_reference(arg)
+                for param, arg in zip(params, args)
+            }
+
+            merged = {**existing_generic_map, **new_entries}
+            setattr(submodel, "__generic_map__", merged)
+
+            # Attach instance-level __getitem__ once so you can do instance[A], instance[B], etc.
+            if "_generic_preserver_instance_getitem" not in submodel.__dict__:
+                def _instance_getitem(self, key: Any):
+                    if isinstance(key, tuple):
+                        return tuple(self[k] for k in key)
+
+                    k = canonical_key(key)
+                    generic_map = getattr(self.__class__, "__generic_map__", {})
+                    if k in generic_map:
+                        return generic_map[k]
+                    raise KeyError(f"No generic type found for generic arg {repr(key)}")
+
+                setattr(submodel, "_generic_preserver_instance_getitem", _instance_getitem)
+                if "__getitem__" not in submodel.__dict__:
+                    submodel.__getitem__ = _instance_getitem  # type: ignore[assignment]
+
+            return submodel
+
         # establish parameters as an iterable
-        type_references = item
-        if not isinstance(type_references, tuple):
-            type_references = (type_references, )
+        args = item
+        if not isinstance(args, tuple):
+            args = (args, )
 
         # ensure it is generic
         if not hasattr(cls, "__orig_bases__"):
@@ -92,10 +151,10 @@ class GenericMeta(type):
             ) from e
 
         # lookup required arguments
-        type_vars = get_args(generic_base)
-        if len(type_vars) != len(type_references):
+        params = get_args(generic_base)
+        if len(params) != len(args):
             raise RuntimeError(
-                f"Incorrect number of type parameters passed. Expected ({len(type_vars)}): {repr(type_vars)}, but received ({len(type_references)}): {repr(type_references)}"
+                f"Incorrect number of type parameters passed. Expected ({len(params)}): {repr(params)}, but received ({len(args)}): {repr(args)}"
             )
 
         # looking up existing generic map to ensure we still capture
@@ -127,8 +186,8 @@ class GenericMeta(type):
 
         # Build the new mapping for this specialisation
         new_entries = {
-            canonical_key(param): resolve_type_reference(type_ref)
-            for param, type_ref in zip(type_vars, type_references)
+            canonical_key(param): resolve_type_reference(arg)
+            for param, arg in zip(params, args)
         }
 
         # Create the specialised class that remembers all resolved bindings

--- a/src/generic_preserver/metaclass.py
+++ b/src/generic_preserver/metaclass.py
@@ -1,14 +1,12 @@
 from typing import get_args
 from typing import Any
+
+from .pydantic_support import specialise_pydantic_generic
 from .utils import (
     copy_class_metadata,
     is_generic_type,
+    canonical_key,
 )
-
-try:
-    from pydantic import BaseModel as PydanticBaseModel
-except ImportError:
-    PydanticBaseModel = None
 
 
 class GenericMeta(type):
@@ -63,6 +61,7 @@ class GenericMeta(type):
     >> KeyError(...)
     ```
     """
+
     def __call__(cls, *args, **kwargs):
         # Check if the class was parameterized
         if not hasattr(cls, "__generic_map__"):
@@ -73,64 +72,15 @@ class GenericMeta(type):
         return super().__call__(*args, **kwargs)
 
     def __getitem__(cls, item):
-        if PydanticBaseModel is not None and isinstance(cls, type) and issubclass(cls, _PydanticBaseModel):
-            # Let Pydantic handle the generic specialisation first
-            submodel = cls.__class_getitem__(item)  # type: ignore[attr-defined]
-
-            # Work out the "origin" generic model and its type parameters
-            meta_sub = getattr(submodel, "__pydantic_generic_metadata__", {}) or {}
-            origin = meta_sub.get("origin") or cls
-
-            origin_meta = getattr(origin, "__pydantic_generic_metadata__", {}) or {}
-            params = origin_meta.get("parameters") or getattr(origin, "__parameters__", ())
-
-            # Concrete type arguments – prefer what's in the metadata
-            args = meta_sub.get("args")
-            if not args:
-                args = item if isinstance(item, tuple) else (item,)
-
-            existing_generic_map = getattr(cls, "__generic_map__", {})
-
-            def canonical_key(tp: Any) -> Any:
-                name = getattr(tp, "__name__", None)
-                return name if name is not None else tp
-
-            def resolve_type_reference(ref: Any) -> Any:
-                # Allow chaining: if the argument is itself a type variable,
-                # we might already have a concrete mapping for it higher up.
-                key = canonical_key(ref)
-                return existing_generic_map.get(key, ref)
-
-            new_entries = {
-                canonical_key(param): resolve_type_reference(arg)
-                for param, arg in zip(params, args)
-            }
-
-            merged = {**existing_generic_map, **new_entries}
-            setattr(submodel, "__generic_map__", merged)
-
-            # Attach instance-level __getitem__ once so you can do instance[A], instance[B], etc.
-            if "_generic_preserver_instance_getitem" not in submodel.__dict__:
-                def _instance_getitem(self, key: Any):
-                    if isinstance(key, tuple):
-                        return tuple(self[k] for k in key)
-
-                    k = canonical_key(key)
-                    generic_map = getattr(self.__class__, "__generic_map__", {})
-                    if k in generic_map:
-                        return generic_map[k]
-                    raise KeyError(f"No generic type found for generic arg {repr(key)}")
-
-                setattr(submodel, "_generic_preserver_instance_getitem", _instance_getitem)
-                if "__getitem__" not in submodel.__dict__:
-                    submodel.__getitem__ = _instance_getitem  # type: ignore[assignment]
-
+        # First, let the Pydantic integration handle BaseModel subclasses.
+        submodel = specialise_pydantic_generic(cls, item)
+        if submodel is not None:
             return submodel
 
         # establish parameters as an iterable
         args = item
         if not isinstance(args, tuple):
-            args = (args, )
+            args = (args,)
 
         # ensure it is generic
         if not hasattr(cls, "__orig_bases__"):
@@ -141,8 +91,7 @@ class GenericMeta(type):
         # lookup the generic base
         try:
             generic_base = next(
-                base for base in cls.__orig_bases__
-                if is_generic_type(base)
+                base for base in cls.__orig_bases__ if is_generic_type(base)
             )
         except StopIteration as e:
             # no generics in this class
@@ -160,17 +109,6 @@ class GenericMeta(type):
         # looking up existing generic map to ensure we still capture
         # generics from super class
         existing_generic_map = getattr(cls, "__generic_map__", {})
-
-        def canonical_key(tp: Any) -> Any:
-            """
-            Produce a stable key for a type parameter.
-
-            - For TypeVar / PEP 695 type parameters: use their name
-              (`.__name__` or `.name`).
-            - For non-type-parameters: just use the object itself.
-            """
-            name = getattr(tp, "__name__", None)
-            return name if name is not None else tp
 
         def resolve_type_reference(ref: Any) -> Any:
             """
@@ -196,6 +134,7 @@ class GenericMeta(type):
             A specialised generic that preserves the type arguments in
             `__generic_map__`.
             """
+
             __generic_map__ = {**existing_generic_map, **new_entries}
 
             def __getitem__(self, item: Any):

--- a/src/generic_preserver/pydantic_support.py
+++ b/src/generic_preserver/pydantic_support.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .utils import canonical_key
+
+try:
+    from pydantic import BaseModel as PydanticBaseModel
+except ImportError:
+    PydanticBaseModel = None
+
+
+def specialise_pydantic_generic(cls: type, item: Any) -> type[PydanticBaseModel] | None:
+    """
+    If `cls` is a Pydantic BaseModel subclass, let Pydantic perform the
+    generic specialisation, then attach/extend `__generic_map__` on the
+    specialised model.
+
+    Returns the specialised subclass, or `None` if:
+
+    - pydantic isn't installed, or
+    - `cls` is not a Pydantic BaseModel subclass.
+    """
+    if PydanticBaseModel is None:
+        return None
+
+    if not isinstance(cls, type) or not issubclass(cls, PydanticBaseModel):
+        return None
+
+    # Let Pydantic create the specialised generic model
+    submodel = cls.__class_getitem__(item)  # type: ignore[attr-defined]
+
+    # Pydantic stores its generic info in `__pydantic_generic_metadata__`
+    meta_sub = getattr(submodel, "__pydantic_generic_metadata__", {}) or {}
+    origin = meta_sub.get("origin") or cls
+
+    origin_meta = getattr(origin, "__pydantic_generic_metadata__", {}) or {}
+    params = origin_meta.get("parameters") or getattr(origin, "__parameters__", ())
+
+    # Concrete type arguments – prefer what's already in the metadata
+    args = meta_sub.get("args")
+    if not args:
+        args = item if isinstance(item, tuple) else (item,)
+
+    existing_generic_map = getattr(cls, "__generic_map__", {})
+
+    def resolve_type_reference(ref: Any) -> Any:
+        """
+        If the argument is itself a type parameter that has already been
+        mapped upstream, resolve via `existing_generic_map`.
+        """
+        key = canonical_key(ref)
+        return existing_generic_map.get(key, ref)
+
+    new_entries = {
+        canonical_key(param): resolve_type_reference(arg)
+        for param, arg in zip(params, args)
+    }
+
+    merged = {**existing_generic_map, **new_entries}
+    setattr(submodel, "__generic_map__", merged)
+
+    # Attach instance-level __getitem__ once so you can do: instance[A], instance[B], ...
+    if "_generic_preserver_instance_getitem" not in submodel.__dict__:
+
+        def _instance_getitem(self, key: Any):
+            if isinstance(key, tuple):
+                return tuple(self[k] for k in key)
+
+            k = canonical_key(key)
+            generic_map = getattr(self.__class__, "__generic_map__", {})
+            if k in generic_map:
+                return generic_map[k]
+
+            raise KeyError(f"No generic type found for generic arg {repr(key)}")
+
+        setattr(submodel, "_generic_preserver_instance_getitem", _instance_getitem)
+
+        # Only define __getitem__ if the model doesn't already define one
+        if "__getitem__" not in submodel.__dict__:
+            submodel.__getitem__ = _instance_getitem  # type: ignore[assignment]
+
+    return submodel

--- a/src/generic_preserver/utils.py
+++ b/src/generic_preserver/utils.py
@@ -1,4 +1,4 @@
-from typing import _GenericAlias
+from typing import Any, _GenericAlias
 
 
 def is_generic_type(obj) -> bool:
@@ -10,8 +10,22 @@ def copy_class_metadata(wrapped, original) -> None:
     """Copy relevant metadata from the original class to the wrapped class."""
     wrapped.__doc__ = original.__doc__
     wrapped.__name__ = original.__name__
-    wrapped.__annotations__ = getattr(original, '__annotations__', {})
-    wrapped.__module__ = getattr(original, '__module__', None)
-    wrapped.__qualname__ = getattr(original, '__qualname__', None)
+    wrapped.__annotations__ = getattr(original, "__annotations__", {})
+    wrapped.__module__ = getattr(original, "__module__", None)
+    wrapped.__qualname__ = getattr(original, "__qualname__", None)
 
     return None
+
+
+def canonical_key(tp: Any) -> Any:
+    """
+    Produce a stable key for a type parameter or type reference.
+
+    - For TypeVar / PEP 695 type parameters: use their name (`.__name__`).
+    - For other objects: use the object itself.
+
+    This allows us to unify separate TypeVar instances that share the same
+    logical name (e.g. multiple `B` parameters across an inheritance chain).
+    """
+    name = getattr(tp, "__name__", None)
+    return name if name is not None else tp

--- a/src/generic_preserver/wrapper.py
+++ b/src/generic_preserver/wrapper.py
@@ -1,80 +1,63 @@
+from __future__ import annotations
+
 from typing import TypeVar
 
 from .metaclass import GenericMeta
-from .utils import (
-    copy_class_metadata,
-)
-from .conflict_management import (
-    build_combined_metaclass_from_cls,
-)
+from .utils import copy_class_metadata
+from .conflict_management import build_combined_metaclass_from_cls
 
 T = TypeVar("T", bound=type)
+
 
 def generic_preserver(cls: T) -> T:
     """
     A decorator that enables capturing generic arguments.
-    _(Skips needing to provide the explicit `metaclass=GenericMeta` parameter in class definition)_
+    _(Skips needing to provide the explicit `metaclass=GenericMeta` parameter in class definition)_.
 
-    Usage:
+    Works with:
+    - Classic TypeVar + Generic[...] style, and
+    - PEP 695: `class Parent[A, B]: ...`
 
-    ```python
-    A = TypeVar("A")
-    B = TypeVar("B")
-    C = TypeVar("C")
-
-    class ExampleA: pass
-    class ExampleB: pass
-    class ExampleC: pass
-
-    @generic_preserver  # <-- Only need to use in the base super class
-    class Parent(
-        Generic[A, B]
-    ):
-        pass
-
-    class Child(
-        Parent[ExampleA, B],
-        Generic[B, C]
-    ): pass
-
-    class GrandChild(
-        Child[ExampleB, C],
-        Generic[C]
-    ): pass
-
-    instance = GrandChild[ExampleC]()
-
-    print(instance[A])
-    >> <class '__main__.ExampleA'>
-
-    print(instance[B])
-    >> <class '__main__.ExampleB'>
-
-    print(instance[C])
-    >> <class '__main__.ExampleC'>
-
-    print(instance.__generic_map__)
-    >> {
-        ~A: <class '__main__.ExampleA'>,
-        ~B: <class '__main__.ExampleB'>,
-        ~C: <class '__main__.ExampleC'>,
-    }
-
-    print(instance[D])
-    >> KeyError(...)
-    ```
+    Also supports Pydantic BaseModel subclasses by *opting out* of
+    Pydantic's own generic param tracking, so that our GenericMeta
+    is the only thing responsible for generics here.
     """
-    # avoid conflict by dynamically creating a metaclass that
-    # groups its base metaclasses (if necessary)
     CombinedMetaclass = build_combined_metaclass_from_cls(
         cls,
         custom_metaclasses=[GenericMeta],
     )
-    
-    # Dynamically create a new class using the GenericMeta metaclass
+
+    # Root wrapper with combined metaclass
     class Wrapped(cls, metaclass=CombinedMetaclass):
-        ...
+        __generic_preserver_root__ = True
+
+        def __init_subclass__(subcls, **kwargs):
+            # Let Pydantic / ABC / user code run their normal hooks first
+            super().__init_subclass__(**kwargs)
+
+            # --- Pydantic compatibility for *all subclasses* ---
+            # If this subclass is a Pydantic model with generic metadata,
+            # blank out its parameters so Pydantic doesn't enforce its own
+            # Generic[...] parameter consistency across this hierarchy.
+            # pmeta = getattr(subcls, "__pydantic_generic_metadata__", None)
+            # if isinstance(pmeta, dict) and "parameters" in pmeta:
+            #     new_meta = dict(pmeta)
+            #     new_meta["parameters"] = ()
+            #     subcls.__pydantic_generic_metadata__ = new_meta
+            # ---------------------------------------------------
 
     copy_class_metadata(Wrapped, cls)
 
-    return Wrapped
+    # --- Pydantic compatibility for the *root* itself ------------
+    # If the root is already a Pydantic model with generic metadata,
+    # clear its parameters too; this prevents the first child from
+    # triggering the "All parameters must be present on typing.Generic"
+    # error when Pydantic compares parent vs child parameters.
+    # root_meta = getattr(Wrapped, "__pydantic_generic_metadata__", None)
+    # if isinstance(root_meta, dict) and "parameters" in root_meta:
+    #     new_root_meta = dict(root_meta)
+    #     # new_root_meta["parameters"] = ()
+    #     Wrapped.__pydantic_generic_metadata__ = new_root_meta
+    # -------------------------------------------------------------
+
+    return Wrapped  # type: ignore[return-value]

--- a/tests/test_abstraction.py
+++ b/tests/test_abstraction.py
@@ -1,5 +1,3 @@
-import pytest
-
 from typing import (
     TypeVar,
     Generic,

--- a/tests/test_abstraction.py
+++ b/tests/test_abstraction.py
@@ -12,15 +12,15 @@ from generic_preserver.wrapper import generic_preserver
 def test():
     T = TypeVar("T")
 
-    class ExampleT: pass
+    class ExampleT:
+        pass
 
     @generic_preserver
-    class AbstractBase(
-        Generic[T],
-        ABC
-    ): pass
+    class AbstractBase(Generic[T], ABC):
+        pass
 
-    class Variant1(AbstractBase[ExampleT]): pass
+    class Variant1(AbstractBase[ExampleT]):
+        pass
 
     instance = Variant1()
 

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -15,24 +15,24 @@ def test():
     B = TypeVar("B")
     C = TypeVar("C")
 
-    class ExampleA: pass
-    class ExampleB: pass
-    class ExampleC: pass
+    class ExampleA:
+        pass
+
+    class ExampleB:
+        pass
+
+    class ExampleC:
+        pass
 
     @generic_preserver
-    class Parent(
-        Generic[A, B]
-    ): pass
+    class Parent(Generic[A, B]):
+        pass
 
-    class Child(
-        Parent[ExampleA, B],
-        Generic[B, C]
-    ): pass
+    class Child(Parent[ExampleA, B], Generic[B, C]):
+        pass
 
-    class GrandChild(
-        Child[ExampleB, C],
-        Generic[C]
-    ): pass
+    class GrandChild(Child[ExampleB, C], Generic[C]):
+        pass
 
     instance = GrandChild[ExampleC]()
 
@@ -51,7 +51,8 @@ def test():
         instance[D]
 
     # check generic of generic
-    class ExampleD(Generic[D]): pass
+    class ExampleD(Generic[D]):
+        pass
 
     instance_2 = Parent[ExampleA, ExampleD[ExampleB]]()
 

--- a/tests/test_inheritance_pep_695.py
+++ b/tests/test_inheritance_pep_695.py
@@ -7,7 +7,9 @@ from generic_preserver.wrapper import generic_preserver
 
 def test():
     class ExampleA: ...
+
     class ExampleB: ...
+
     class ExampleC: ...
 
     @generic_preserver

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -15,7 +15,9 @@ def test():
     D = TypeVar("D")
 
     class ExampleA(BaseModel): ...
+
     class ExampleB(BaseModel): ...
+
     class ExampleC(BaseModel): ...
 
     @generic_preserver
@@ -33,8 +35,7 @@ def test():
             return self[B]
 
         @abstractmethod
-        def do_something(self) -> str:
-            ...
+        def do_something(self) -> str: ...
 
     class Child(Parent[ExampleA, B], Generic[B, C]):
         child_extra: C

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1,0 +1,111 @@
+import pytest
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, ValidationError
+
+from generic_preserver.wrapper import generic_preserver
+
+from typing import Generic, TypeVar
+
+
+def test():
+    A = TypeVar("A")
+    B = TypeVar("B")
+    C = TypeVar("C")
+    D = TypeVar("D")
+
+    class ExampleA(BaseModel): ...
+    class ExampleB(BaseModel): ...
+    class ExampleC(BaseModel): ...
+
+    @generic_preserver
+    class Parent(BaseModel, Generic[A, B], ABC):
+        # sample field using the type parameter A
+        sample: A
+        meta: B | None = None
+
+        @property
+        def a_type(self):  # noqa: N802
+            return self[A]
+
+        @property
+        def b_type(self):  # noqa: N802
+            return self[B]
+
+        @abstractmethod
+        def do_something(self) -> str:
+            ...
+
+    class Child(Parent[ExampleA, B], Generic[B, C]):
+        child_extra: C
+
+        @property
+        def c_type(self):  # noqa: N802
+            return self[C]
+
+        def do_something(self) -> str:
+            return "ok"
+
+    class GrandChild(Child[ExampleB, C], Generic[C]):
+        pass
+
+    # instantiate a fully specialised Pydantic model
+    instance = GrandChild[ExampleC](
+        sample=ExampleA(),
+        meta=ExampleB(),
+        child_extra=ExampleC(),
+    )
+
+    # check single type extraction via properties
+    assert instance.a_type is ExampleA
+    assert instance.b_type is ExampleB
+    assert instance.c_type is ExampleC
+
+    # check the underlying generic map is fully flattened
+    assert instance.__generic_map__ == {
+        "A": ExampleA,
+        "B": ExampleB,
+        "C": ExampleC,
+    }
+
+    # invalid lookup still raises KeyError
+    with pytest.raises(KeyError):
+        instance[TypeVar("E")]  # new, unrelated TypeVar
+
+    # --- generic-of-generic case with BaseModel -------------------
+
+    class ExampleD(BaseModel, Generic[D]):
+        value: D
+
+    class ConcreteParent(Parent[ExampleA, ExampleD[ExampleB]]):
+        def do_something(self) -> str:
+            return "ok"
+
+    instance_2 = ConcreteParent(
+        sample=ExampleA(),
+        meta=ExampleD[ExampleB](value=ExampleB()),
+    )
+
+    assert instance_2.a_type is ExampleA
+    assert instance_2.b_type is ExampleD[ExampleB]
+    assert instance_2[A, B] == (
+        ExampleA,
+        ExampleD[ExampleB],
+    )
+
+    # --- validation error checks ---------------------------------
+
+    # 1) Wrong type for `sample` (expects ExampleA, gets a plain string)
+    with pytest.raises(ValidationError):
+        GrandChild[ExampleC](
+            sample="not ExampleA",
+            meta=ExampleB(),
+            child_extra=ExampleC(),
+        )
+
+    # 2) Wrong nested type for ExampleD[ExampleB].value
+    with pytest.raises(ValidationError):
+        ConcreteParent(
+            sample=ExampleA(),
+            meta=ExampleD[ExampleB](value="not ExampleB"),
+        )

--- a/tests/test_pydantic_pep_695.py
+++ b/tests/test_pydantic_pep_695.py
@@ -8,7 +8,9 @@ from generic_preserver.wrapper import generic_preserver
 
 def test():
     class ExampleA(BaseModel): ...
+
     class ExampleB(BaseModel): ...
+
     class ExampleC(BaseModel): ...
 
     @generic_preserver
@@ -26,8 +28,7 @@ def test():
             return self[B]
 
         @abstractmethod
-        def do_something(self) -> str:
-            ...
+        def do_something(self) -> str: ...
 
     class Child[B, C](Parent[ExampleA, B]):
         child_extra: C
@@ -63,6 +64,7 @@ def test():
 
     # invalid lookup still raises KeyError
     class D: ...
+
     with pytest.raises(KeyError):
         instance[D]
 
@@ -102,4 +104,3 @@ def test():
             sample=ExampleA(),
             meta=ExampleD[ExampleB](value="not ExampleB"),
         )
-

--- a/tests/test_pydantic_pep_695.py
+++ b/tests/test_pydantic_pep_695.py
@@ -1,0 +1,105 @@
+import pytest
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, ValidationError
+
+from generic_preserver.wrapper import generic_preserver
+
+
+def test():
+    class ExampleA(BaseModel): ...
+    class ExampleB(BaseModel): ...
+    class ExampleC(BaseModel): ...
+
+    @generic_preserver
+    class Parent[A, B](BaseModel, ABC):
+        # sample field using the type parameter A
+        sample: A
+        meta: B | None = None
+
+        @property
+        def a_type(self):  # noqa: N802
+            return self[A]
+
+        @property
+        def b_type(self):  # noqa: N802
+            return self[B]
+
+        @abstractmethod
+        def do_something(self) -> str:
+            ...
+
+    class Child[B, C](Parent[ExampleA, B]):
+        child_extra: C
+
+        @property
+        def c_type(self):  # noqa: N802
+            return self[C]
+
+        def do_something(self) -> str:
+            return "ok"
+
+    class GrandChild[C](Child[ExampleB, C]):
+        pass
+
+    # instantiate a fully specialised Pydantic model
+    instance = GrandChild[ExampleC](
+        sample=ExampleA(),
+        meta=ExampleB(),
+        child_extra=ExampleC(),
+    )
+
+    # check single type extraction via properties
+    assert instance.a_type is ExampleA
+    assert instance.b_type is ExampleB
+    assert instance.c_type is ExampleC
+
+    # check the underlying generic map is fully flattened
+    assert instance.__generic_map__ == {
+        "A": ExampleA,
+        "B": ExampleB,
+        "C": ExampleC,
+    }
+
+    # invalid lookup still raises KeyError
+    class D: ...
+    with pytest.raises(KeyError):
+        instance[D]
+
+    # generic-of-generic case with BaseModel
+    class ExampleD[D](BaseModel):
+        value: D
+
+    class ConcreteParent(Parent[ExampleA, ExampleD[ExampleB]]):
+        def do_something(self) -> str:
+            return "ok"
+
+    instance_2 = ConcreteParent(
+        sample=ExampleA(),
+        meta=ExampleD[ExampleB](value=ExampleB()),
+    )
+
+    assert instance_2.a_type is ExampleA
+    assert instance_2.b_type is ExampleD[ExampleB]
+    assert instance_2["A", "B"] == (
+        ExampleA,
+        ExampleD[ExampleB],
+    )
+
+    # --- validation error checks ---------------------------------
+
+    # 1) Wrong type for `sample` (expects ExampleA, gets a plain string)
+    with pytest.raises(ValidationError):
+        GrandChild[ExampleC](
+            sample="not ExampleA",
+            meta=ExampleB(),
+            child_extra=ExampleC(),
+        )
+
+    # 2) Wrong nested type for ExampleD[ExampleB].value
+    with pytest.raises(ValidationError):
+        ConcreteParent(
+            sample=ExampleA(),
+            meta=ExampleD[ExampleB](value="not ExampleB"),
+        )
+


### PR DESCRIPTION
### Summary

This PR makes `generic-preserver` play nicely with **Pydantic generics** (v2) without disabling Pydantic’s own generic machinery, and cleans up the implementation so it’s maintainable for contributors.

Previously, attempting to use `@generic_preserver` with a Pydantic `BaseModel` generic inheritance chain like:

```python
@generic_preserver
class Parent(BaseModel, Generic[A, B]): ...
class Child(Parent[ExampleA, B], Generic[B, C]): ...
class GrandChild(Child[ExampleB, C], Generic[C]): ...
```

could trigger Pydantic’s generic consistency error:

> `TypeError: All parameters must be present on typing.Generic; you should inherit from typing.Generic[A, B, B, C].`

We initially “fixed” this by zeroing out Pydantic’s `__pydantic_generic_metadata__['parameters']`, but that effectively disabled Pydantic’s own generic support and weakened validation.

This PR replaces that hack with a proper integration layer.

---

### Key Changes

#### 1. Add `canonical_key` helper

**File:** `utils.py`

* Introduced `canonical_key(tp: Any) -> Any`:

  * For type parameters (TypeVar / PEP 695 params), we use their `. __name__`.
  * For other objects, we use the object itself.

* This gives us a **stable key** across multiple generics that reuse the same logical parameter name (`A`, `B`, etc.) and fixes the “nested TypeVar” issue where a type argument could be another type parameter instead of the final concrete type.

#### 2. Extract Pydantic-specific logic into `pydantic_support.py`

**New file:** `pydantic_support.py`

* Added `specialise_pydantic_generic(cls, item)`:

  * Detects if `cls` is a Pydantic `BaseModel` subclass.

  * Delegates generic specialisation to Pydantic via `cls.__class_getitem__(item)`.

  * Reads Pydantic’s `__pydantic_generic_metadata__` from the origin + specialised model to get:

    * type parameters (`parameters` / `__parameters__`)
    * concrete arguments (`args`)

  * Builds/extends a `__generic_map__` on the specialised model, using `canonical_key` and resolving chained type references (so a `B` parameter bound upstream to `ExampleB` is preserved).

  * Attaches an instance-level `__getitem__` (if not already present) so you can do:

    ```python
    instance[A]        # -> ExampleA
    instance[B]        # -> ExampleB
    instance[A, B]     # -> (ExampleA, ExampleB)
    ```

  * Returns the specialised Pydantic model, or `None` if Pydantic isn’t installed / `cls` is not a `BaseModel` subclass.

* This keeps all Pydantic knowledge in one place, making the core metaclass implementation framework-agnostic.

#### 3. Refactor `GenericMeta.__getitem__` to delegate to Pydantic integration

**File:** `metaclass.py`

* `GenericMeta.__call__` is unchanged in behaviour:

  * Still enforces that a class must have `__generic_map__` (i.e. must be parameterised with `[...]`) before instantiation.

* `GenericMeta.__getitem__` is now split into two clearly separated paths:

  1. **Pydantic-aware path**

     ```python
     submodel = specialise_pydantic_generic(cls, item)
     if submodel is not None:
         return submodel
     ```

     * If `cls` is a `BaseModel` subclass and Pydantic is available, we:

       * Let Pydantic create the generic specialisation.
       * Extend `__generic_map__` on that specialisation.
       * Provide instance-level `__getitem__` for generic lookup.
       * Crucially, we **do not** mutate Pydantic’s `__pydantic_generic_metadata__`.
       * Pydantic generics and validation continue to work as intended.

  2. **Non-Pydantic generic path (original behaviour)**

     * Uses `__orig_bases__` + `is_generic_type` + `get_args` to find the generic base.

     * Uses `canonical_key` and `existing_generic_map` to:

       * Fix the PEP 695 case where type arguments can be type parameters that are already mapped upstream.
       * Merge mappings across inheritance chains (`Parent`, `Child`, `GrandChild`).

     * Creates a `PreservedGeneric` subclass with:

       ```python
       __generic_map__ = {**existing_generic_map, **new_entries}
       ```

     * Defines instance `__getitem__` that:

       * Supports multi-lookup (`self[A, B]` → tuple).
       * Looks up via `canonical_key`.
       * Falls back to `super().__getitem__` if present, otherwise raises `KeyError`.

     * Calls `copy_class_metadata` to keep `__name__`, `__qualname__`, `__doc__`, etc.

This preserves the existing behaviour for non-Pydantic generics while cleanly adding first-class support for Pydantic’s generics.

---

### 4. Pydantic Tests

**File:** `tests/test_pydantic.py` (or equivalent)

* Added a Pydantic-focused test that covers:

  * **Python 3.11-style generics**:

    ```python
    A = TypeVar("A")
    B = TypeVar("B")
    C = TypeVar("C")
    D = TypeVar("D")

    @generic_preserver
    class Parent(BaseModel, Generic[A, B], ABC):
        sample: A
        meta: B | None = None
        ...
    ```

  * Inheritance chain:

    ```python
    class Child(Parent[ExampleA, B], Generic[B, C]): ...
    class GrandChild(Child[ExampleB, C], Generic[C]): ...
    ```

  * A **generic-of-generic** model:

    ```python
    class ExampleD(Generic[D], BaseModel):
        value: D

    class ConcreteParent(Parent[ExampleA, ExampleD[ExampleB]]): ...
    ```

* Assertions include:

  * Generic map flattening:

    ```python
    instance = GrandChild[ExampleC](...)
    assert instance.a_type is ExampleA
    assert instance.b_type is ExampleB
    assert instance.c_type is ExampleC

    assert instance.__generic_map__ == {
        "A": ExampleA,
        "B": ExampleB,
        "C": ExampleC,
    }
    ```

  * Invalid lookups still raising `KeyError`:

    ```python
    with pytest.raises(KeyError):
        instance[TypeVar("E")]
    ```

  * Pydantic validation still working as expected, including nested generic validation via `ExampleD[ExampleB]`.

This confirms that:

* The original Pydantic error

  > `TypeError: All parameters must be present on typing.Generic; you should inherit from typing.Generic[A, B, B, C].`

  is resolved *without* disabling Pydantic’s generic metadata, and

* `generic-preserver` now cooperates with Pydantic rather than fighting it, while still supporting PEP 695 and classic generics in non-Pydantic code.
